### PR TITLE
ignore decoding errors

### DIFF
--- a/ircconnector.py
+++ b/ircconnector.py
@@ -53,18 +53,14 @@ class IRCConnector(threading.Thread):
     def run(self):
         while True:
             ircmsg = self.ircsock.recv(8192)
-            try:
-                ircmsg = ircmsg.decode().strip('\n\r')
-            except Exception as e:
-                print(e)
-            else:
-                if DEBUG:
-                    print(ircmsg)
-                message = IRCMessage(ircmsg)
-                if message.isValid():
-                    if message.msgType == 'PING':
-                        self.ping()
-                    else:
-                        if LOG_ENABLE:
-                            print(message)
-                        self.msgQueue.put({'type': 'irc', 'content': message})
+            ircmsg = ircmsg.decode(errors = 'ignore').strip('\n\r')
+            if DEBUG:
+                print(ircmsg)
+            message = IRCMessage(ircmsg)
+            if message.isValid():
+                if message.msgType == 'PING':
+                    self.ping()
+                else:
+                    if LOG_ENABLE:
+                        print(message)
+                    self.msgQueue.put({'type': 'irc', 'content': message})


### PR DESCRIPTION
bytes 배열을 decode할 때 깨진 문자가 있으면 무시하도록 변경함
https://docs.python.org/3/library/stdtypes.html#bytes.decode